### PR TITLE
"Insert" export and binary blobs

### DIFF
--- a/fbexport/FBExport.cpp
+++ b/fbexport/FBExport.cpp
@@ -54,6 +54,7 @@
 
 #include <string>
 #include <cstring>
+#include <sstream>
 
 #include "ParseArgs.h"
 #include "FBExport.h"
@@ -372,18 +373,25 @@ string FBExport::CreateHumanString(IBPP::Statement& st, int col)
 
     if (ar->ExportFormat == xefInserts && !numeric)
     {
-        string::size_type pos = string::npos;
-        while (true)
-        {
-            pos = value.find_last_of('\'', pos);
-            if (pos == string::npos)
-                break;
-            value.insert(pos, 1, '\'');
-            if (pos == 0)
-                break;
-            pos--;
+        stringstream stringBuilder;
+        stringBuilder << '\'';
+        for (int i=0; i<value.size(); i++) {
+            char next_char = value.c_str()[i];
+
+            if(next_char == '\0') {
+                stringBuilder << "\\0";
+            } else if(next_char == '\n') {
+                stringBuilder << "\\n";
+            } else if(next_char == '\\') {
+                stringBuilder << "\\\\";
+            } else if(next_char == '\'') {
+                stringBuilder << "''";
+            } else {
+                stringBuilder << next_char;
+            }
         }
-        value = "'" + value + "'";      // INSERTs, use single quotes for non-numeric values
+        stringBuilder << '\'';
+        return stringBuilder.str();
     }
 
     return value;


### PR DESCRIPTION
While trying to export a Firebird database to MySQL by using an SQL export ("Insert"), I found the binary blobs were not exported properly. Most notably, the null-bytes don't play too well with the "string" container.

This change replaces the string escaping for all kinds of strings in the SQL export to add a few more character escapes (heavily influenced by http://dev.mysql.com/doc/refman/5.7/en/string-literals.html since MySQL is my target for those exports).

Note : a similar change may be needed for CSV export. Also, C++ isn't necessarily my most used language, code style/improvements welcome ! :)